### PR TITLE
Add new `/` root route to API

### DIFF
--- a/examples/analog_read/analog-read-client.html
+++ b/examples/analog_read/analog-read-client.html
@@ -21,7 +21,7 @@
 
     window.onload = function() {
       // Connect to the main api socket
-      cylon = io('http://127.0.0.1:3000/api/robots');
+      cylon = io('http://127.0.0.1:3000/api');
 
       console.log('Setting up socket connections:');
 
@@ -120,6 +120,10 @@
           $('#messages').append($('<li>').text(msg));
         }
       });
+
+      // Send the api a 'robots' to receive the list of robots
+      // and trigger the listener we defined above.
+      cylon.emit('robots');
 
       $('form').submit(function(){
         device.emit('message', $('#m').val());

--- a/examples/blink_led/blink-client.html
+++ b/examples/blink_led/blink-client.html
@@ -21,7 +21,7 @@
 
     window.onload = function() {
       // Connect to the main api socket
-      cylon = io('http://127.0.0.1:3000/api/robots');
+      cylon = io('http://127.0.0.1:3000/api');
 
       console.log('Setting up socket connections:');
 
@@ -94,6 +94,10 @@
           $('#messages').append($('<li>').text(msg));
         }
       });
+
+      // Send the api a 'robots' to receive the list of robots
+      // and trigger the listener we defined above.
+      cylon.emit('robots');
 
       $('form').submit(function(){
         robot.emit('message', $('#m').val());

--- a/examples/generic_message_event/blink-client.html
+++ b/examples/generic_message_event/blink-client.html
@@ -21,7 +21,7 @@
 
     window.onload = function() {
       // Connect to the main api socket
-      cylon = io('http://127.0.0.1:3000/api/robots');
+      cylon = io('http://127.0.0.1:3000/api');
 
       console.log('Setting up socket connections:');
 
@@ -84,6 +84,10 @@
           $('#messages').append($('<li>').text(msg));
         }
       });
+
+      // Send the api a 'robots' to receive the list of robots
+      // and trigger the listener we defined above.
+      cylon.emit('robots');
     };
   </script>
   <body>

--- a/examples/robot_events_commands/robot-events-commands-client.html
+++ b/examples/robot_events_commands/robot-events-commands-client.html
@@ -21,7 +21,7 @@
 
     window.onload = function() {
       // Connect to the main api socket
-      cylon = io('http://127.0.0.1:3000/api/robots');
+      cylon = io('http://127.0.0.1:3000/api');
 
       console.log('Setting up socket connections:');
 
@@ -109,6 +109,10 @@
           $('#messages').append($('<li>').text(msg));
         }
       });
+
+      // Send the api a 'robots' to receive the list of robots
+      // and trigger the listener we defined above.
+      cylon.emit('robots');
 
       $('form').submit(function(){
         robot.emit('message', $('#m').val());

--- a/lib/socket-master.js
+++ b/lib/socket-master.js
@@ -38,24 +38,24 @@ SocketMaster.prototype.start = function() {
 
 SocketMaster.prototype._socketItems = function(nsp, items, callback) {
   _.forIn(items, function(item, name) {
-    var nspName;
+    var nspAndName;
 
     name = name.toLowerCase();
-    nspName = nsp + name;
+    nspAndName = nsp + name;
 
-    if (!this.nsp[name]) {
-      console.log('Creating new socket for: ' + nspName);
+    if (!this.nsp[nspAndName]) {
+      console.log('Creating new socket for: ' + nspAndName);
 
-      this.nsp[name] = this.io.of(nspName);
+      this.nsp[nspAndName] = this.io.of(nspAndName);
 
-      this.nsp[name].on('connection', function(socket) {
-        console.log('User connected to socket: ', nspName);
+      this.nsp[nspAndName].on('connection', function(socket) {
+        console.log('User connected to socket: ', nspAndName);
 
         socket.on('disconnect', function() {
-          console.log('User disconnected from socket: ', nspName);
+          console.log('User disconnected from socket: ', nspAndName);
         });
 
-        callback(socket, name, item);
+        callback(socket, nspAndName, item);
       });
     }
   }, this);
@@ -64,34 +64,41 @@ SocketMaster.prototype._socketItems = function(nsp, items, callback) {
 SocketMaster.prototype.socketMCP = function() {
   console.log('Setting up API socket...');
 
-  var callback = function(socket, name, robots) {
-    var robotNames = _.map(robots, function(val, key) {
+  var callback = function(socket, nspRoute, mcp) {
+    var mcpJSON = mcp.toJSON(),
+        nsp = this.nsp[nspRoute];
+
+    var robotsNames = _.map(mcp.robots, function(val, key) {
       return key.toLowerCase();
     });
 
-    socket.on('robots', function() {
-      this.nsp[name].emit('robots', robotNames);
-    }.bind(this));
+    socket.on('/', function() {
+      nsp.emit('/', mcpJSON);
+    });
 
-    this.nsp[name].emit('robots', robotNames);
+    socket.on('robots', function() {
+      nsp.emit('robots', robotsNames);
+    });
+
+    nsp.emit('/', mcpJSON);
   }.bind(this);
 
-  this._socketItems('/api/', { robots: this.mcp.robots }, callback);
+  this._socketItems('/api', { '': this.mcp }, callback);
 };
 
 SocketMaster.prototype.socketRobots = function(robots) {
   console.log('Setting up robot sockets...');
 
-  var callback = function(socket, name, robot) {
+  var callback = function(socket, nspRoute, robot) {
     var devices = _.keys(robot.devices);
 
     socket.on('devices', function() {
-      this.nsp[name].emit('devices', devices);
+      this.nsp[nspRoute].emit('devices', devices);
     }.bind(this));
 
-    this._addDefaultListeners(socket, name, robot);
+    this._addDefaultListeners(socket, nspRoute, robot);
 
-    this.nsp[name].emit('devices', devices);
+    this.nsp[nspRoute].emit('devices', devices);
   }.bind(this);
 
   this._socketItems('/api/robots/', robots, callback);
@@ -106,41 +113,41 @@ SocketMaster.prototype.socketDevices = function(robot) {
   this._socketItems(nsp, robot.devices, this._addDefaultListeners.bind(this));
 };
 
-SocketMaster.prototype._addDefaultListeners = function(socket, name, item) {
+SocketMaster.prototype._addDefaultListeners = function(sck, nspRoute, item) {
 
-  socket.on('message', function(data) {
-    var nsp = this.nsp[name];
+  sck.on('message', function(data) {
+    var nspSocket = this.nsp[nspRoute];
 
-    this._nspEmit(nsp, 'message', data);
+    this._nspEmit(nspSocket, 'message', data);
   }.bind(this));
 
-  socket.on('commands', function() {
+  sck.on('commands', function() {
     var commands = _.keys(item.commands),
-        nsp = this.nsp[name];
+        nspSocket = this.nsp[nspRoute];
 
-    this._nspEmit(nsp, 'commands', commands);
+    this._nspEmit(nspSocket, 'commands', commands);
   }.bind(this));
 
-  socket.on('events', function() {
+  sck.on('events', function() {
     var events = item.events,
-        nsp = this.nsp[name];
+        nspSocket = this.nsp[nspRoute];
 
-    this._nspEmit(nsp, 'events', events);
+    this._nspEmit(nspSocket, 'events', events);
   }.bind(this));
 
-  socket.on('command', function(opts) {
+  sck.on('command', function(opts) {
     var ret = item.commands[opts.command].apply(item, opts.args),
-        nsp = this.nsp[name];
+        ns = this.nsp[nspRoute];
 
-    this._nspEmit(nsp, 'command', { command: opts.command, returned: ret });
+    this._nspEmit(ns, 'command', { command: opts.command, returned: ret });
   }.bind(this));
 
   _.forIn(item.commands, function(command, cname) {
-    socket.on(cname, function() {
+    sck.on(cname, function() {
       var ret = command.apply(item, arguments),
-          nsp = this.nsp[name];
+          nspSocket = this.nsp[nspRoute];
 
-      this._nspEmit(nsp, cname, ret);
+      this._nspEmit(nspSocket, cname, ret);
     }.bind(this));
   }, this);
 
@@ -148,10 +155,10 @@ SocketMaster.prototype._addDefaultListeners = function(socket, name, item) {
     if (item.listeners(eventName).length < 1) {
       item.on(eventName, function(data) {
         var args = _.toArray(arguments),
-        nsp = this.nsp[name];
+        nspSocket = this.nsp[nspRoute];
 
-        nsp.emit('message', this._msgPayload(eventName, data));
-        nsp.emit.apply(nsp, [eventName].concat(args));
+        nspSocket.emit('message', this._msgPayload(eventName, data));
+        nspSocket.emit.apply(nspSocket, [eventName].concat(args));
       }.bind(this));
     }
   }, this);
@@ -169,7 +176,7 @@ SocketMaster.prototype._msgPayload = function(eventName, data) {
   };
 };
 
-SocketMaster.prototype._nspEmit = function(nsp, eventName, data) {
-  nsp.emit('message', this._msgPayload(eventName, data));
-  nsp.emit(eventName, data);
+SocketMaster.prototype._nspEmit = function(nspSocket, eventName, data) {
+  nspSocket.emit('message', this._msgPayload(eventName, data));
+  nspSocket.emit(eventName, data);
 };


### PR DESCRIPTION
We can now pull a json with the MCP structure by creating a `/api` socket and doing one of the following:
```javascript
// we create a socket to api root
cylon = io('http://127.0.0.1:3000/api');

// returns MCP.toJSON()
cylon.on('/', function(mcpJSON) { // do ur thang! });
cylon.emit('/');

cylon.on('mcp', function(mcpJSON) { // do ur thang! });
cylon.emit('mcp');


// returns a list of robots
cylon.on('robots', function(robotsNames) { // do ur thang! });
cylon.emit('robots');
```

peace out!